### PR TITLE
patch: fix incorrect authentication urls

### DIFF
--- a/django_project/base/templates/join_organization_request.html
+++ b/django_project/base/templates/join_organization_request.html
@@ -4,30 +4,70 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Join Request Notification</title>
+    <style>
+        body {
+            font-family: Helvetica, sans-serif;
+            margin: 0;
+            padding: 0;
+            background-color: #f4f4f4;
+        }
+        .container {
+            width: 90%;
+            max-width: 900px;
+            margin: 0 auto;
+            background-color: #ffffff;
+            border: 10px solid #dddddd;
+            padding: 20px;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        }
+        .header {
+            background-color: #2f5c4a;
+            color: #ffffff;
+            padding: 10px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .header img {
+            width: 150px;
+        }
+        .button {
+            display: inline-block;
+            background-color: #FFA500;
+            color: #ffffff;
+            padding: 15px 50px;
+            text-decoration: none;
+            border-radius: 5px;
+            text-align: center;
+            font-size: 16px;
+        }
+        @media (max-width: 768px) {
+            .header {
+                flex-direction: column;
+                text-align: center;
+            }
+            .button {
+                padding: 10px 30px;
+                font-size: 14px;
+            }
+        }
+    </style>
 </head>
-<body style="font-family: Helvetica, sans-serif; margin: 0; padding: 0; background-color: #f4f4f4;">
-    <table align="center" width="900" style="background-color: #2f5c4a; padding: 10px;">
-        <tr>
-            <td align="left" width="50%" style="padding: 10px;">
-                <img src="https://arw.sta.do.kartoza.com/static/images/main_logo.svg" alt="Logo" width="200">
-            </td>
-            <td align="right" width="50%" style="padding: 10px; color: #ffffff;">
-                <h2>Africa Rangeland Watch</h2>
-            </td>
-        </tr>
-    </table>
-    <table align="center" width="900" style="background-color: #ffffff; padding: 20px; border: 10px solid #dddddd;">
-        <tr>
-            <td style="padding: 20px;">
-                <h2>Hello Admin,</h2>
-                <p>{{ requester.first_name }} {{ requester.last_name }} has requested to join <strong>{{ organisation.name }}</strong>.</p>
-                <p>Click below to review the request:</p>
-                <p style="text-align: center;">
-                    <a href="{{ admin_link }}" style="background-color: #FFA500; color: #ffffff; padding: 15px 50px; text-decoration: none; border-radius: 5px;">Review Request</a>
-                </p>
-                <p>If you have any questions, contact us at <a href="mailto:support@africarangelandwatch.com">support@africarangelandwatch.com</a>.</p>
-            </td>
-        </tr>
-    </table>
+<body>
+    <div class="container">
+        <div class="header">
+            <img src="https://arw.sta.do.kartoza.com/static/images/main_logo.svg" alt="Logo">
+            <h2>Africa Rangeland Watch</h2>
+        </div>
+        <div class="content">
+            <h2>Dear Organisation Manager,</h2>
+            <p>{{ user.first_name }} {{ user.last_name }} has requested to join <strong>{{ organisation }}</strong>.</p>
+            <p>Click below to review the request:</p>
+            <p style="text-align: center;">
+                <a href="{{ link }}" class="button">Review Request</a>
+            </p>
+            <p>If you have any questions, contact us at <a href="mailto:support@africarangelandwatch.com">support@africarangelandwatch.com</a>.</p>
+        </div>
+    </div>
 </body>
 </html>

--- a/django_project/core/custom_auth_view.py
+++ b/django_project/core/custom_auth_view.py
@@ -90,7 +90,7 @@ class CustomRegistrationView(APIView):
             token = default_token_generator.make_token(user)
             uid = urlsafe_base64_encode(str(user.pk).encode())
             activation_link = f"{
-                settings.DJANGO_BACKEND_URL}/auth/activate/{uid}/{token}/"
+                settings.DJANGO_BACKEND_URL}/activate/{uid}/{token}/"
 
             # Send email with activation link
             subject = "Activate Your Account"
@@ -189,7 +189,7 @@ class ForgotPasswordView(APIView):
         uid = urlsafe_base64_encode(str(user.pk).encode())
 
         reset_password_link = (
-            f"{settings.DJANGO_BACKEND_URL}/auth/password-reset/"
+            f"{settings.DJANGO_BACKEND_URL}/password-reset/"
             f"{uid}/{token}/"
         )
 


### PR DESCRIPTION
Description

The links sent via register and forgot passed when clicked were opening a page that says requested resource could not be found . This was because the url is being incorrectly constructed before the email is sent .

I have fixed this.