### PR TITLE
Use cid to display images in emails

### DIFF
--- a/django_project/core/custom_auth_view.py
+++ b/django_project/core/custom_auth_view.py
@@ -23,6 +23,7 @@ from rest_framework.decorators import api_view
 from django.contrib.auth import logout
 from allauth.account.models import EmailAddress
 from email.mime.image import MIMEImage
+from django.contrib.staticfiles.finders import find
 
 
 @api_view(["POST"])
@@ -135,10 +136,12 @@ class CustomRegistrationView(APIView):
                 from_email=settings.NO_REPLY_EMAIL,
                 to=[email]
             )
-            with open('static/images/main_logo.svg', 'rb') as img_file:
-                image = MIMEImage(img_file.read())
-                image.add_header('Content-ID', '<logo_image>')
-                email_message.attach(image)
+            logo_path = find('images/main_logo.svg')
+
+            if logo_path:
+                with open(logo_path, 'rb') as img_file:
+                    image = MIMEImage(img_file.read(), _subtype="svg+xml")
+                    image.add_header('Content-ID', '<logo_image>')
             email_message.attach_alternative(html_message, "text/html")
             email_message.send()
 

--- a/django_project/core/custom_auth_view.py
+++ b/django_project/core/custom_auth_view.py
@@ -22,7 +22,7 @@ from django.core.mail import EmailMultiAlternatives
 from rest_framework.decorators import api_view
 from django.contrib.auth import logout
 from allauth.account.models import EmailAddress
-from django.core.mail.mime.image import MIMEImage
+from email.mime.image import MIMEImage
 
 
 @api_view(["POST"])

--- a/django_project/core/custom_auth_view.py
+++ b/django_project/core/custom_auth_view.py
@@ -22,6 +22,7 @@ from django.core.mail import EmailMultiAlternatives
 from rest_framework.decorators import api_view
 from django.contrib.auth import logout
 from allauth.account.models import EmailAddress
+from django.core.mail.mime.image import MIMEImage
 
 
 @api_view(["POST"])
@@ -134,6 +135,10 @@ class CustomRegistrationView(APIView):
                 from_email=settings.NO_REPLY_EMAIL,
                 to=[email]
             )
+            with open('static/images/main_logo.svg', 'rb') as img_file:
+                image = MIMEImage(img_file.read())
+                image.add_header('Content-ID', '<logo_image>')
+                email_message.attach(image)
             email_message.attach_alternative(html_message, "text/html")
             email_message.send()
 

--- a/django_project/core/templates/account/email_confirmation.html
+++ b/django_project/core/templates/account/email_confirmation.html
@@ -10,7 +10,7 @@
         <tr>
             <!-- Left Column: Logo -->
             <td align="left" width="50%" style="padding: 10px;">
-                <img src="https://arw.dev.do.kartoza.com/static/images/main_logo.svg" alt="Logo" width="200" style="display: block;">
+                <img src="cid:logo_image" alt="Logo" width="200" style="display: block;">
             </td>
             <td align="right" width="50%" style="padding: 10px; color: #ffffff; font-family: Helvetica,sans-serif;">
                 <h2 style="margin: 0; font-size: 24px;">Africa Rangeland Watch</h2>


### PR DESCRIPTION
Problem

currently all emails being sent from the site have the logo missing 
I had to open the email with thunderbird and enable it to accept remote content for the image to appear
so this will not be sufficient 

rather as a solution
use CID
 This allows embedding an image as an attachment and reference it in the email's HTML content. The email client will render the image automatically without needing to fetch it externally.


so i only set this one email to test on dev
once its successful i can update the rest of the email templates