### PR TITLE
remove id param from url

### DIFF
--- a/django_project/base/organisation_views.py
+++ b/django_project/base/organisation_views.py
@@ -64,7 +64,6 @@ def join_organisation(request):
 
     link = (
         f"{settings.DJANGO_BACKEND_URL}/admin/base/organisationinvitation/"
-        f"{selected_org.id}/change/"
     )
     logo_url = f"{settings.DJANGO_BACKEND_URL}/static/images/main_logo.svg"
     email_body = render_to_string(


### PR DESCRIPTION
this is linked to issue:
https://github.com/kartoza/africa_rangeland_watch/issues/226



this will be the new destination of the link where the admin will select the email and appropriate action
![Screenshot from 2025-01-15 10-02-15](https://github.com/user-attachments/assets/92e287f5-141e-4b83-adc8-beb013ac3309)
