### PR TITLE
Potential fix for code scanning alert no. 15: Information exposure through an exception

### DIFF
--- a/django_project/base/organisation_views.py
+++ b/django_project/base/organisation_views.py
@@ -292,7 +292,9 @@ def delete_organisation_member(request):
         )
 
     except Exception as e:
-        logging.error("An error occurred while deleting organisation member: %s", str(e))
+        logging.error(
+            "An error occurred while deleting organisation member: %s", 
+            str(e))
         return JsonResponse(
             {"error": "An internal error has occurred."},
             status=500
@@ -354,7 +356,9 @@ def fetch_organisation_data(request):
             status=500,
         )
     except Exception as e:
-        logging.error("An unexpected error occurred while fetching organisation data: %s", str(e))
+        logging.error(
+            "An unexpected error occurred: %s", 
+            str(e))
         return JsonResponse(
             {"error": "An unexpected error has occurred."},
             status=500,

--- a/django_project/base/organisation_views.py
+++ b/django_project/base/organisation_views.py
@@ -293,7 +293,7 @@ def delete_organisation_member(request):
 
     except Exception as e:
         logging.error(
-            "An error occurred while deleting organisation member: %s", 
+            "An error occurred while deleting organisation member: %s",
             str(e))
         return JsonResponse(
             {"error": "An internal error has occurred."},
@@ -357,7 +357,7 @@ def fetch_organisation_data(request):
         )
     except Exception as e:
         logging.error(
-            "An unexpected error occurred: %s", 
+            "An unexpected error occurred: %s",
             str(e))
         return JsonResponse(
             {"error": "An unexpected error has occurred."},

--- a/django_project/base/organisation_views.py
+++ b/django_project/base/organisation_views.py
@@ -19,7 +19,7 @@ from django.conf import settings
 from django.template.loader import render_to_string
 from django.core.mail import EmailMultiAlternatives
 from django.db import IntegrityError
-
+import logging
 
 Invitation = get_invitation_model()
 
@@ -292,8 +292,9 @@ def delete_organisation_member(request):
         )
 
     except Exception as e:
+        logging.error("An error occurred while deleting organisation member: %s", str(e))
         return JsonResponse(
-            {"error": "An error occurred.", "details": str(e)},
+            {"error": "An internal error has occurred."},
             status=500
         )
 
@@ -347,16 +348,15 @@ def fetch_organisation_data(request):
         return JsonResponse(data, status=200)
 
     except AttributeError as e:
+        logging.error("User profile setup error: %s", str(e))
         return JsonResponse(
-            {
-                "error": "User profile is not set up correctly.",
-                "details": str(e),
-            },
+            {"error": "User profile is not set up correctly."},
             status=500,
         )
     except Exception as e:
+        logging.error("An unexpected error occurred while fetching organisation data: %s", str(e))
         return JsonResponse(
-            {"error": "An unexpected error occurred.", "details": str(e)},
+            {"error": "An unexpected error has occurred."},
             status=500,
         )
 


### PR DESCRIPTION
Potential fix for [https://github.com/kartoza/africa_rangeland_watch/security/code-scanning/15](https://github.com/kartoza/africa_rangeland_watch/security/code-scanning/15)

To fix the problem, we need to ensure that detailed error information is not exposed to the end user. Instead, we should log the error details on the server and return a generic error message to the user. This can be achieved by using Python's logging module to log the exception details and modifying the JSON response to exclude the exception details.

1. Import the logging module.
2. Configure the logging settings if not already configured.
3. Replace the current exception handling code to log the exception details and return a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
