### PR TITLE
Potential fix for code scanning alert no. 22: Information exposure through an exception

### DIFF
--- a/django_project/dashboard/views.py
+++ b/django_project/dashboard/views.py
@@ -11,7 +11,9 @@ from rest_framework.permissions import (
     IsAuthenticated,
     IsAuthenticatedOrReadOnly
 )
+import logging
 
+logger = logging.getLogger(__name__)
 
 class DashboardListCreateView(generics.ListCreateAPIView):
     """
@@ -175,8 +177,9 @@ class DashboardCreateView(APIView):
             )
 
         except Exception as e:
+            logger.error("An error occurred while creating the dashboard: %s", str(e))
             return Response(
-                {"error": True, "message": str(e)},
+                {"error": True, "message": "An internal error has occurred."},
                 status=status.HTTP_400_BAD_REQUEST
             )
 

--- a/django_project/dashboard/views.py
+++ b/django_project/dashboard/views.py
@@ -15,6 +15,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 class DashboardListCreateView(generics.ListCreateAPIView):
     """
     View for listing and creating dashboards.
@@ -177,7 +178,8 @@ class DashboardCreateView(APIView):
             )
 
         except Exception as e:
-            logger.error("An error occurred while creating the dashboard: %s", str(e))
+            logger.error(
+                "An error occurred while creating the dashboard: %s", str(e))
             return Response(
                 {"error": True, "message": "An internal error has occurred."},
                 status=status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
Potential fix for [https://github.com/kartoza/africa_rangeland_watch/security/code-scanning/22](https://github.com/kartoza/africa_rangeland_watch/security/code-scanning/22)

To fix the problem, we need to modify the exception handling in the `DashboardCreateView` class to log the detailed error message on the server and return a generic error message to the user. This will prevent sensitive information from being exposed to external users while still allowing developers to access the detailed error information in the server logs.

1. Import the `logging` module to enable logging of error messages.
2. Configure a logger for the module.
3. Modify the exception handling block to log the detailed error message and return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
