### PR TITLE
Implement analysis results filters

### DIFF
--- a/django_project/frontend/src/pages/AnalysisResults/index.tsx
+++ b/django_project/frontend/src/pages/AnalysisResults/index.tsx
@@ -21,6 +21,10 @@ import {
   AlertDialogHeader,
   AlertDialogBody,
   AlertDialogFooter,
+  Collapse,
+  IconButton,
+  Select,
+  SimpleGrid,
 } from "@chakra-ui/react";
 import { FaFilter } from "react-icons/fa";
 import Header from "../../components/Header";
@@ -36,6 +40,8 @@ import { deleteAnalysis, fetchAnalysis } from "../../store/userAnalysisSlice";
 import "maplibre-gl/dist/maplibre-gl.css"; 
 import CreateDashboardModal from "../../components/CreateDashboard";
 import { format } from 'date-fns';
+import { IoCloseSharp } from "react-icons/io5";
+import { ChevronUpIcon } from "@chakra-ui/icons";
 
 interface FeatureProperties {
   Project?: string;
@@ -70,7 +76,6 @@ interface AnalysisSummary {
 
 export default function AnalysisResults() {
   const [searchTerm, setSearchTerm] = useState("");
-  const [showAll, setShowAll] = useState(false);
   const [selectedAnalysis, setSelectedAnalysis] = useState([]);
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [isCreateDashboardOpen, setCreateDashboard] = useState(false);
@@ -86,6 +91,10 @@ export default function AnalysisResults() {
   const [isConfrimDeleteOpen, setIsConfirmDeleteOpen] = useState(false);
   const onConfirmDeleteClose = () => setIsConfirmDeleteOpen(false);
   const cancelRef = React.useRef();
+  const [region, setRegion] = useState("");
+  const [date, setDate] = useState("");
+  const [type, setType] = useState("");
+  const [isFilterOpen, setIsFilterOpen] = useState(false); 
 
 
   useEffect(() => {
@@ -130,39 +139,48 @@ export default function AnalysisResults() {
    }
   }, [analysisDeleted]);
 
-  const getAnalysisSummary = (analysis: AnalysisData): AnalysisSummary => {
+  const getAnalysisSummary = (analysis: any): AnalysisSummary => {
     const { analysis_results } = analysis || {};
     const { results, data } = analysis_results || {};
-
+  
     const features = results?.[0]?.features || [];
-    const { analysisType = "Analysis", latitude, longitude } = data || {};
-
+    const { analysisType = "Analysis", latitude, longitude, landscape } = data || {};
+  
     // Extract properties safely
     const projectName = features?.[0]?.properties?.Project || "Unknown Project";
-    const locationName = features?.[0]?.properties?.Name || "Coordinates Location";
-
+  
     // Construct a meaningful title
     const title =
-      locationName === "Coordinates Location" && projectName === "Unknown Project"
-        ? `${analysisType} Results from Area`
+      landscape && landscape !== "Unknown Landscape" 
+        ? `${analysisType} Analysis of ${landscape}`
         : projectName === "Unknown Project"
-          ? `${analysisType} Analysis of ${locationName} in the Area`
-          : `${analysisType} Analysis of ${locationName} in the ${projectName} Landscape.`;
-
+        ? `${analysisType} Results from Area`
+        : `${analysisType} Analysis of ${landscape} in the ${projectName} Landscape.`;
+    
     return {
       title,
       projectName,
-      locationName,
+      locationName: landscape,
       analysisType,
       latitude,
       longitude,
     };
   };
+  
 
   // Filtering based on search term
-  const filteredData = analysisData.filter((analysis: AnalysisData) =>
-      getAnalysisSummary(analysis).title.toLowerCase().includes(searchTerm.toLowerCase())
-  );
+  const filteredData = analysisData.filter((analysis: any) => {
+    const titleMatches = getAnalysisSummary(analysis).title.toLowerCase().includes(searchTerm.toLowerCase());
+    const typeMatches = type ? analysis.analysis_results.data?.analysisType.toLowerCase() === type : true;
+    const dateMatches = date
+      ? format(new Date(analysis?.created_at), "yyyy-MM-dd") === date
+      : true; // Filter only if a date is selected
+    const regionMatches = region ? analysis.analysis_results.data?.landscape === region : true;
+  
+    return titleMatches && typeMatches && dateMatches && regionMatches;
+  });
+  
+  
 
   const handleViewClick = (analysis: any) => {
     onOpen();
@@ -214,6 +232,10 @@ export default function AnalysisResults() {
     throw new Error("Function not implemented.");
   }
 
+  const landscapeOptions = Array.from(
+    new Set(analysisData.map((analysis: any) => analysis.analysis_results.data?.landscape))
+  ).filter(Boolean); // Remove null/undefined values
+
   return (
     <>
       <Helmet>
@@ -245,8 +267,8 @@ export default function AnalysisResults() {
                 <Flex direction={{ base: "column", md: "row" }} gap={4} align="center">
                   {/* Filter Button */}
                   <Button
-                      disabled
-                    leftIcon={<FaFilter />}
+                    leftIcon={isFilterOpen ? undefined : <FaFilter />}
+                    rightIcon={isFilterOpen ? <ChevronUpIcon boxSize={6} /> : undefined}
                     colorScheme="green"
                     variant="solid"
                     backgroundColor="dark_green.800"
@@ -254,10 +276,12 @@ export default function AnalysisResults() {
                     fontWeight={700}
                     w={{ base: "100%", md: "auto" }}
                     h={10}
-                    color="white.a700"
-                    borderRadius="0px"
+                    color="white"
+                    borderRadius="5px"
+                    onClick={() => setIsFilterOpen(!isFilterOpen)}
+                    transition="all 0.3s ease-in-out"
                   >
-                    Filter
+                    {!isFilterOpen ? "Filter" : ""}
                   </Button>
 
                   {/* Search Input */}
@@ -307,8 +331,78 @@ export default function AnalysisResults() {
               </Box>
             </Flex>
 
+            {/* Filter Section */}
+            <Collapse in={isFilterOpen} animateOpacity>
+              <Box
+                bg="gray.100"
+                p={4}
+                borderRadius="10px"
+                boxShadow="md"
+                width={{ base: "90%", md: "50%" }} // Reduced width
+                alignSelf="flex-start" 
+              >
+                <Flex justify="space-between" align="center" mb={3}>
+                  <Text fontSize="lg" fontWeight="bold" color="gray.700">
+                    Filter Analysis
+                  </Text>
+                  <IconButton
+                    icon={<IoCloseSharp />}
+                    size="sm"
+                    onClick={() => setIsFilterOpen(!isFilterOpen)}
+                    aria-label="Close filters"
+                    variant="ghost"
+                    color="gray.600"
+                    _hover={{ color: "red.500" }}
+                  />
+                </Flex>
+
+                {/* 2-column layout for fields */}
+                <SimpleGrid columns={2} spacing={4}>
+                  {/* Region Dropdown */}
+                  <Select 
+                    placeholder="Select Region" 
+                    value={region} 
+                    onChange={(e) => setRegion(e.target.value)} 
+                    borderColor="gray.400"
+                  >
+                    {landscapeOptions.map((landscape, index) => (
+                      <option key={index} value={String(landscape)}>
+                        {String(landscape)}
+                      </option>
+                    ))}
+                  </Select>
+
+                  {/* Date Field */}
+                  <Input
+                    type="date"
+                    value={date}
+                    onChange={(e) => setDate(e.target.value)}
+                    borderColor="gray.400"
+                  />
+
+                  {/* Type Filter */}
+                  <Select placeholder="Select Type" value={type} onChange={(e) => setType(e.target.value)} borderColor="gray.400">
+                    <option value="baseline">Baseline</option>
+                    <option value="temporal">Temporal</option>
+                    <option value="spatial">Spatial</option>
+                  </Select>
+
+
+                  {/* Apply Filters Button */}
+                  <Button variant="ghost" onClick={() => {
+                    setRegion("");
+                    setDate("");
+                    setType("");
+                  }}>
+                    Clear Filters
+                  </Button>
+
+                </SimpleGrid>
+              </Box>
+            </Collapse>
+
             {/* Content Section */}
-            <Divider mb={6} borderColor="black" borderWidth="1px" width="calc(100% - 10px)" />
+            <Divider mb={6} borderColor="black" borderWidth="1px" width="calc(100% - 10px)" mt={4}/>
 
             {loading && <Text>Loading...</Text>}
             {!loading && !filteredData?.length && <Text>No analysis data available.</Text>}


### PR DESCRIPTION
this is linked to issue:
[implement filters on analysis results page](https://github.com/kartoza/africa_rangeland_watch/issues/335)


Done

- adjusted the title to show landscape
- add filters section

[Screencast from 2025-02-11 11-31-54.webm](https://github.com/user-attachments/assets/45844797-5856-4ace-8b83-ac344879d03d)
