### PR TITLE
add earthranger api to fetch events

### DIFF
--- a/django_project/core/urls.py
+++ b/django_project/core/urls.py
@@ -82,6 +82,7 @@ urlpatterns = [
     ),
     path('', include('dashboard.urls')),
     path('', include('analysis.urls')),
+    path('', include('earthranger.urls')),
 ]
 
 if settings.DEBUG:

--- a/django_project/earthranger/serializers.py
+++ b/django_project/earthranger/serializers.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+from .models import EarthRangerEvents
+
+
+class EarthRangerEventsSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = EarthRangerEvents
+        fields = ["name", "data", "last_updated"]

--- a/django_project/earthranger/urls.py
+++ b/django_project/earthranger/urls.py
@@ -3,9 +3,9 @@ from .views import list_events, fetch_event_details
 
 
 urlpatterns = [
-    path("events/", list_events, name="list_events"),
+    path("earthranger/events/", list_events, name="list_events"),
     path(
-        "events/<str:event_id>/",
+        "earthranger/events/<str:event_id>/",
         fetch_event_details,
         name="fetch_event_details"
     ),

--- a/django_project/earthranger/urls.py
+++ b/django_project/earthranger/urls.py
@@ -1,0 +1,12 @@
+from django.urls import path
+from .views import list_events, fetch_event_details
+
+
+urlpatterns = [
+    path("events/", list_events, name="list_events"),
+    path(
+        "events/<str:event_id>/",
+        fetch_event_details,
+        name="fetch_event_details"
+    ),
+]

--- a/django_project/earthranger/views.py
+++ b/django_project/earthranger/views.py
@@ -1,0 +1,71 @@
+from django.shortcuts import get_object_or_404
+from rest_framework.response import Response
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
+from rest_framework import status
+from django.conf import settings
+import requests
+import logging
+from .models import EarthRangerEvents
+
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def list_events(request):
+    """
+    Fetch all stored events with optional filtering.
+    """
+
+    # Extract optional filters from query parameters
+    event_type = request.GET.get("event_type")
+    event_category = request.GET.get("event_category")
+
+    # Get the stored event data
+    event_instance = get_object_or_404(EarthRangerEvents, name="Events")
+
+    # Extract JSON data
+    event_data = event_instance.data.get("data", {}).get("results", [])
+
+    # Apply filters
+    if event_type:
+        event_data = [
+            event for event in event_data
+            if event.get("event_type") == event_type
+        ]
+
+    if event_category:
+        event_data = [
+            event for event in event_data
+            if event.get("event_category") == event_category
+        ]
+
+    return Response({"events": event_data}, status=status.HTTP_200_OK)
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def fetch_event_details(request, event_id):
+    """
+    Fetch details of a specific event using its ID from Earth Ranger API.
+    """
+    api_url = f"{settings.EARTH_RANGER_API_URL}/activity/event/{event_id}/"
+    headers = {
+        "accept": "application/json",
+        "X-CSRFToken": settings.EARTH_RANGER_CSRF_TOKEN,
+        "Authorization": f"Bearer {settings.EARTH_RANGER_AUTH_TOKEN}"
+    }
+
+    response = requests.get(api_url, headers=headers)
+
+    if response.status_code == 200:
+        return Response(response.json(), status=status.HTTP_200_OK)
+
+    logging.error(
+        f"Failed to fetch event details: {response.status_code}"
+        f" - {response.text}"
+    )
+    return Response(
+        {
+            "error": "Failed to fetch event details"
+        }, status=response.status_code)


### PR DESCRIPTION
Description

- This API allows us to query the data fetched from earthranger api 
- It also allows us to apply filters like event type and category 
- Also created another API to fetch a specific events details using the event id

These are the functionalities that were requested by the client . What will be left is the frontend implementation (details for those don't exist yet)

[Screencast from 2025-02-27 11-02-18.webm](https://github.com/user-attachments/assets/c2dc0dfb-0615-48bb-9474-7e1addb247f6)
