### PR TITLE
View for Categorizing Alerts/Notifications

### DIFF
--- a/django_project/alerts/urls.py
+++ b/django_project/alerts/urls.py
@@ -2,7 +2,8 @@ from rest_framework.routers import DefaultRouter
 from .views import (
     IndicatorViewSet,
     AlertSettingViewSet,
-    IndicatorAlertHistoryViewSet
+    IndicatorAlertHistoryViewSet,
+    CategorizedAlertsView,
 )
 
 router = DefaultRouter()
@@ -20,6 +21,11 @@ router.register(
     r'alert-histories',
     IndicatorAlertHistoryViewSet,
     basename='alert-history'
+)
+router.register(
+    r'categorized-alerts',
+    CategorizedAlertsView,
+    basename='categorized-alert'
 )
 
 urlpatterns = router.urls

--- a/django_project/frontend/src/pages/Notifications/index.tsx
+++ b/django_project/frontend/src/pages/Notifications/index.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import Helmet from "react-helmet";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import {
   Box,
   Heading,
@@ -25,6 +26,32 @@ export default function Notifications() {
   const handleSettingsClick = () => {
     setSelectedTabIndex(4); // Switch to "Settings" tab
   };
+
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  const handleTabChange = (index: number) => {
+    const tabParam = ["all", "personal", "organization", "system"][index];
+    navigate(`/notifications?tab=${tabParam}`);
+    setSelectedTabIndex(index);
+  };
+
+  useEffect(() => {
+    const tabMap = {
+      all: 0,
+      personal: 1,
+      organization: 2,
+      system: 3,
+    } as const;
+    
+    type TabKey = keyof typeof tabMap;
+    
+    const tabParam = searchParams.get("tab");
+    
+    if (tabParam && tabParam in tabMap) {
+      setSelectedTabIndex(tabMap[tabParam as TabKey]);
+    }
+  }, []);
 
   return (
     <>
@@ -56,7 +83,7 @@ export default function Notifications() {
               variant="enclosed"
               isLazy
               index={selectedTabIndex}
-              onChange={setSelectedTabIndex} // Directly update the index
+              onChange={handleTabChange} // Directly update the index
             >
               <TabList display="flex" alignItems="center">
                 <Tab _selected={{ color: "white", bg: "dark_green.800" }}>All</Tab>
@@ -73,16 +100,16 @@ export default function Notifications() {
 
               <TabPanels>
                 <TabPanel>
-                  <NotificationsTab />
+                  <NotificationsTab category="all"/>
                 </TabPanel>
                 <TabPanel>
-                  <Text fontSize="m" fontWeight="bold" color="gray.500">No data available for Personal notifications.</Text>
+                  <NotificationsTab category="personal"/>
                 </TabPanel>
                 <TabPanel>
-                  <Text fontSize="m" fontWeight="bold" color="gray.500">No data available for Organisations notifications.</Text>
+                  <NotificationsTab category="organisation"/>
                 </TabPanel>
                 <TabPanel>
-                  <Text fontSize="m" fontWeight="bold" color="gray.500">No data available for System notifications.</Text>
+                  <NotificationsTab category="system"/>
                 </TabPanel>
                 <TabPanel>
                   <SystemTab />

--- a/django_project/frontend/src/pages/Notifications/notificationsTab.tsx
+++ b/django_project/frontend/src/pages/Notifications/notificationsTab.tsx
@@ -8,19 +8,47 @@ import {
 import "../../styles/index.css";
 import Pagination from "../../components/Pagination";
 
-export default function NotificationsTab() {
+export default function NotificationsTab({ category }: { category: string }) {
   const [allNotifications, setAllNotifications] = useState<any[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 5;
 
   useEffect(() => {
-    const fetchNotificationsData = () => {
-
-      setAllNotifications([]);
+    const fetchNotificationsData = async () => {
+      try {
+        const response = await fetch(
+          `/api/categorized-alerts/categorized/?category=${category}`,
+          {
+            headers: {
+              "Content-Type": "application/json",
+              "Authorization": `Bearer ${localStorage.getItem("token")}` // or remove if using session auth
+            }
+          }
+        );
+  
+        if (!response.ok) {
+          throw new Error("Failed to fetch notifications");
+        }
+  
+        const data = await response.json();
+  
+        const formatted = data.map((item: any) => ({
+          id: item.id,
+          title: item.alert_setting?.name || "Unnamed Alert",
+          description: item.text || "No description provided.",
+          badge: category.charAt(0).toUpperCase() + category.slice(1),
+          timestamp: new Date(item.created_at).toLocaleString()
+        }));
+  
+        setAllNotifications(formatted);
+      } catch (err) {
+        console.error("Error fetching notifications:", err);
+        setAllNotifications([]);
+      }
     };
-
+  
     fetchNotificationsData();
-  }, []);
+  }, [category]);
 
   const totalPages = Math.ceil(allNotifications.length / itemsPerPage);
   const indexOfLastItem = currentPage * itemsPerPage;

--- a/django_project/frontend/src/pages/Notifications/notificationsTab.tsx
+++ b/django_project/frontend/src/pages/Notifications/notificationsTab.tsx
@@ -21,7 +21,6 @@ export default function NotificationsTab({ category }: { category: string }) {
           {
             headers: {
               "Content-Type": "application/json",
-              "Authorization": `Bearer ${localStorage.getItem("token")}` // or remove if using session auth
             }
           }
         );


### PR DESCRIPTION
Fixes #411


https://github.com/user-attachments/assets/2e926dbf-9b56-431e-8668-8ce45937e7e2


@dimasciput @danangmassandy What are your thoughts on the below questions?

For organisational alerts, should users be able to choose whether their alerts are visible to others within their organisation? Currently they are visible by default if they are in the same organisation.
- This will require something like `share_with_organisation` flag in alert_settings.

Or should alerts be owned by the organisation itself (not just by individual users)?
- This will probably require an `organisation` field in `AlertSetting` model. 

For system alerts, should alerts exist that apply globally to all users regardless of user or organisation?
- This will require allowing the user field in `AlertSetting` to be nullable, so that the alert is not tied to any specific user.
- Or use a system default user? So that maybe we don't have to use null user entries