### PR TITLE
fix permission when viewing public dashboard

### DIFF
--- a/django_project/dashboard/tests/test_dashboard_views.py
+++ b/django_project/dashboard/tests/test_dashboard_views.py
@@ -380,7 +380,7 @@ class DashboardDetailViewTests(TestCase):
         url = f"/dashboards/{self.dashboard.uuid}/detail/"
         response = self.client.get(url)
         
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_get_non_existent_dashboard(self):
         """Test retrieving details of a non-existent dashboard."""

--- a/django_project/dashboard/views.py
+++ b/django_project/dashboard/views.py
@@ -417,7 +417,7 @@ class DashboardDetailView(APIView):
                     "error":
                     "You do not have permission to view this dashboard."
                 },
-                status=status.HTTP_401_UNAUTHORIZED
+                status=status.HTTP_404_NOT_FOUND
             )
         serializer = DashboardDetailSerializer(dashboard)
         return Response(serializer.data)


### PR DESCRIPTION
<img width="931" height="337" alt="2025-11-10_23-43" src="https://github.com/user-attachments/assets/fae21d86-e1e7-44c3-a162-7bdfcf594e7f" />

Got 401 error when viewing public dashboard as below, this PR will fix the issue.

<img width="908" height="211" alt="2025-11-10_23-42" src="https://github.com/user-attachments/assets/1e5c6a94-a2fa-44a2-9dd7-b90e823b67f6" />
