### PR TITLE
Disable multiple comparison year on BACI Frontend

### DIFF
--- a/django_project/analysis/models.py
+++ b/django_project/analysis/models.py
@@ -878,7 +878,8 @@ class BaseIndicator(models.Model):
     ALLOWED_ANALYSIS_TYPES = [
         'Baseline',
         'Temporal',
-        'Spatial'
+        'Spatial',
+        'BACI'
     ]
     ALLOWED_TEMPORAL_RESOLUTIONS = [
         'Annual',

--- a/django_project/frontend/src/components/Map/LeftSide/Analysis/index.tsx
+++ b/django_project/frontend/src/components/Map/LeftSide/Analysis/index.tsx
@@ -491,7 +491,7 @@ export default function Analysis({ landscapes, layers, onLayerChecked, onLayerUn
             value={data.comparisonPeriod}
             isQuarter={data.temporalResolution === TemporalResolution.QUARTERLY}
             isMonthly={data.temporalResolution === TemporalResolution.MONTHLY}
-            multiple={[Types.TEMPORAL, Types.SPATIAL, Types.BACI].includes(data.analysisType)}
+            multiple={[Types.TEMPORAL, Types.SPATIAL].includes(data.analysisType)}
             maxLength={data.analysisType === Types.SPATIAL ? 1 : 100}
             onSelectedYear={(value: number) => {
               setData({


### PR DESCRIPTION
This is PR for [[BUG] BACI analysis not running](https://github.com/kartoza/africa_rangeland_watch/issues/657#top). It was caused by BACI backend only support single comparison year, while on frontend it supports multiple comparison years. I remove multiple comparison years on the frontend.

<img width="1920" height="899" alt="image" src="https://github.com/user-attachments/assets/ef7cae87-4588-4b92-8fda-45baa4c8b1ab" />